### PR TITLE
add replay functionality

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -31,7 +31,8 @@ class Info(commands.Cog):
         ['resume', 'Resumes music'],
         ['currentsong', 'Display current song'],
         ['skip', 'Skips the current song'],
-        ['queue', 'Get queue info']
+        ['queue', 'Get queue info'],
+        ['replay', 'Enable/disable replay of the entire queue']
       ]
       for row in rows:
         row[0] = COMMAND_PREFIX + row[0]


### PR DESCRIPTION
## Description
This PR adds a new `$replay` command to the music bot to enable/disable replaying the entire queue. 
```text
+--------------+-------------------------------------------+
|   command    |                description                |
+--------------+-------------------------------------------+
|    $play     |       Play music from YouTube source      |
|    $stop     |      Stops music and disconnects bot      |
|    $pause    |                Pauses music               |
|   $resume    |               Resumes music               |
| $currentsong |            Display current song           |
|    $skip     |           Skips the current song          |
|    $queue    |               Get queue info              |
|   $replay    | Enable/disable replay of the entire queue |
+--------------+-------------------------------------------+
```