### PR TITLE
add remove command to remove songs from the queue

### DIFF
--- a/commands/info.py
+++ b/commands/info.py
@@ -32,7 +32,8 @@ class Info(commands.Cog):
         ['currentsong', 'Display current song'],
         ['skip', 'Skips the current song'],
         ['queue', 'Get queue info'],
-        ['replay', 'Enable/disable replay of the entire queue']
+        ['replay', 'Enable/disable replay of the entire queue'],
+        ['remove', 'Remove a song from the queue']
       ]
       for row in rows:
         row[0] = COMMAND_PREFIX + row[0]

--- a/commands/music_player.py
+++ b/commands/music_player.py
@@ -1,6 +1,7 @@
 # customized version of https://gist.github.com/EvieePy/ab667b74e9758433b3eb806c53a19f34#file-music-py
 import asyncio
 import discord
+import itertools
 import logging
 from async_timeout import timeout
 from functools import partial
@@ -16,7 +17,7 @@ log = logging.getLogger('bot')
 
 class YTDLSource():
 
-  def __init__(self, source, title, webpage_url, filepath, requester,  ctx):
+  def __init__(self, source, title, webpage_url, filepath, requester, ctx):
     self.source = source
     self.requester = requester
 
@@ -73,6 +74,25 @@ class MusicPlayer:
     if e:
       log.error(e)
     self.bot.loop.call_soon_threadsafe(self.next.set)
+  
+  def get_upcoming(self):
+    return list(itertools.islice(self.queue._queue, 0, self.queue.qsize()))
+  
+  # remove an element from the queue given a position
+  async def remove(self, pos: int):
+    if pos <= 0:
+      return
+
+    new_queue = asyncio.Queue()
+    current_pos = 0
+
+    while not self.queue.empty():
+      item = await self.queue.get()
+      current_pos += 1
+      if current_pos != pos:
+        await new_queue.put(item)
+    
+    self.queue = new_queue
 
   def clear_queue(self):
     for _ in range(self.queue.qsize()):


### PR DESCRIPTION
## Description
Adds a new `$remove` command to remove songs from the queue at a given position
```text
+--------------+-------------------------------------------+
|   command    |                description                |
+--------------+-------------------------------------------+
|    $play     |       Play music from YouTube source      |
|    $stop     |      Stops music and disconnects bot      |
|    $pause    |                Pauses music               |
|   $resume    |               Resumes music               |
| $currentsong |            Display current song           |
|    $skip     |           Skips the current song          |
|    $queue    |               Get queue info              |
|   $replay    | Enable/disable replay of the entire queue |
|   $remove    |        Remove a song from the queue       |
+--------------+-------------------------------------------+
```
### Example usage

Use `queue` command
```text
Upcoming - Next 3 (Replay is enabled)
1. Who Remembers Newjeans? The Iconic 90's R&b Group Is Back!(Attention 90's R&B Remix)
2. 정국 (Jung Kook) 'Seven ' Hansohee Vibe Remix by Marukaobeats
3. 優しい彗星
```

Use `remove` command
```
$remove 2
```

Use `queue` command to verify result
```
Upcoming - Next 2 (Replay is enabled)
1. Who Remembers Newjeans? The Iconic 90's R&b Group Is Back!(Attention 90's R&B Remix)
2. 優しい彗星
```
